### PR TITLE
[Feat] 주문 생성 기능 구현

### DIFF
--- a/backend/src/main/java/com/team6/cafe/domain/coffee/service/CoffeeService.java
+++ b/backend/src/main/java/com/team6/cafe/domain/coffee/service/CoffeeService.java
@@ -29,4 +29,8 @@ public class CoffeeService {
 
 		return CoffeeResponseDto.from(coffee);
 	}
+
+	public long count() {
+		return coffeeRepository.count();
+	}
 }

--- a/backend/src/main/java/com/team6/cafe/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/team6/cafe/domain/order/controller/OrderController.java
@@ -21,7 +21,7 @@ public class OrderController {
 
 	private final OrderService orderService;
 
-	@Operation(summary = "Order 생성")
+	@Operation(summary = "주문 생성")
 	@PostMapping("/create")
 	public ResponseEntity<OrderResponseDto> create(@RequestBody @Valid OrderRequestDto request) {
 		OrderResponseDto response = orderService.create(request);

--- a/backend/src/main/java/com/team6/cafe/domain/order/dto/OrderResponseDto.java
+++ b/backend/src/main/java/com/team6/cafe/domain/order/dto/OrderResponseDto.java
@@ -2,9 +2,11 @@ package com.team6.cafe.domain.order.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.team6.cafe.domain.order.entity.Order;
 import com.team6.cafe.domain.orderCoffee.dto.OrderCoffeeResponseDto;
+import com.team6.cafe.domain.orderCoffee.entity.OrderCoffee;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,7 +27,20 @@ public class OrderResponseDto {
 	private int totalPrice;
 	private List<OrderCoffeeResponseDto> orderCoffees;
 
-	public static OrderResponseDto from(Order order) {
-		return new OrderResponseDto(); // 미구현
+	public static OrderResponseDto from(Order order, List<OrderCoffee> orderCoffees) {
+		List<OrderCoffeeResponseDto> orderCoffeeDtos = orderCoffees.stream()
+			.map(OrderCoffeeResponseDto::from)
+			.collect(Collectors.toList());
+
+		return new OrderResponseDto(
+			order.getId(),
+			order.getEmail(),
+			order.getOrderTime(),
+			order.getModifyTime(),
+			order.isStatus(),
+			order.getAddress(),
+			order.getTotalPrice(),
+			orderCoffeeDtos
+		);
 	}
 }

--- a/backend/src/main/java/com/team6/cafe/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/team6/cafe/domain/order/entity/Order.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SoftDelete
-@Table(name = "order")
+@Table(name = "orders")
 public class Order {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/team6/cafe/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team6/cafe/domain/order/service/OrderService.java
@@ -7,14 +7,12 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.team6.cafe.domain.coffee.dto.CoffeeResponseDto;
 import com.team6.cafe.domain.coffee.entity.Coffee;
 import com.team6.cafe.domain.coffee.repository.CoffeeRepository;
 import com.team6.cafe.domain.order.dto.OrderRequestDto;
 import com.team6.cafe.domain.order.dto.OrderResponseDto;
 import com.team6.cafe.domain.order.entity.Order;
 import com.team6.cafe.domain.order.repository.OrderRepository;
-import com.team6.cafe.domain.orderCoffee.dto.OrderCoffeeResponseDto;
 import com.team6.cafe.domain.orderCoffee.entity.OrderCoffee;
 import com.team6.cafe.domain.orderCoffee.repository.OrderCoffeeRepository;
 
@@ -23,5 +21,38 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class OrderService {
+	private final OrderRepository orderRepository;
+	private final CoffeeRepository coffeeRepository;
+	private final OrderCoffeeRepository orderCoffeeRepository;
 
+	@Transactional
+	public OrderResponseDto createOrder(OrderRequestDto orderRequestDto) {
+		Order order = Order.builder()
+			.email(orderRequestDto.getEmail())
+			.address(orderRequestDto.getAddress())
+			.totalPrice(orderRequestDto.getTotalPrice())
+			.orderTime(LocalDateTime.now())
+			.modifyTime(LocalDateTime.now())
+			.status(false) // 기본값: 배송 전
+			.build();
+
+		Order savedOrder = orderRepository.save(order);
+
+		List<OrderCoffee> orderCoffees = orderRequestDto.getOrderCoffees().stream()
+			.map(dto -> {
+				Coffee coffee = coffeeRepository.findById(dto.getCoffeeId())
+					.orElseThrow(() -> new IllegalArgumentException("해당 커피를 찾을 수 없습니다: " + dto.getCoffeeId()));
+
+				return OrderCoffee.builder()
+					.order(savedOrder)
+					.coffee(coffee)
+					.quantity(dto.getQuantity())
+					.build();
+			})
+			.collect(Collectors.toList());
+
+		orderCoffeeRepository.saveAll(orderCoffees);
+
+		return OrderResponseDto.from(savedOrder, orderCoffees);
+	}
 }

--- a/backend/src/main/java/com/team6/cafe/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team6/cafe/domain/order/service/OrderService.java
@@ -26,7 +26,7 @@ public class OrderService {
 	private final OrderCoffeeRepository orderCoffeeRepository;
 
 	@Transactional
-	public OrderResponseDto createOrder(OrderRequestDto orderRequestDto) {
+	public OrderResponseDto create(OrderRequestDto orderRequestDto) {
 		Order order = Order.builder()
 			.email(orderRequestDto.getEmail())
 			.address(orderRequestDto.getAddress())

--- a/backend/src/main/java/com/team6/cafe/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team6/cafe/domain/order/service/OrderService.java
@@ -1,12 +1,22 @@
 package com.team6.cafe.domain.order.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.team6.cafe.domain.coffee.dto.CoffeeResponseDto;
+import com.team6.cafe.domain.coffee.entity.Coffee;
+import com.team6.cafe.domain.coffee.repository.CoffeeRepository;
 import com.team6.cafe.domain.order.dto.OrderRequestDto;
 import com.team6.cafe.domain.order.dto.OrderResponseDto;
 import com.team6.cafe.domain.order.entity.Order;
 import com.team6.cafe.domain.order.repository.OrderRepository;
+import com.team6.cafe.domain.orderCoffee.dto.OrderCoffeeResponseDto;
+import com.team6.cafe.domain.orderCoffee.entity.OrderCoffee;
+import com.team6.cafe.domain.orderCoffee.repository.OrderCoffeeRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,17 +24,4 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderService {
 
-	private final OrderRepository orderRepository;
-
-	@Transactional
-	public OrderResponseDto create(OrderRequestDto request) {
-		Order order = orderRepository.save(
-			Order.builder()
-				.email(request.getEmail())
-				.address(request.getAddress())
-				.build()
-		);
-
-		return OrderResponseDto.from(order); // 미구현
-	}
 }

--- a/backend/src/main/java/com/team6/cafe/domain/orderCoffee/dto/OrderCoffeeRequestDto.java
+++ b/backend/src/main/java/com/team6/cafe/domain/orderCoffee/dto/OrderCoffeeRequestDto.java
@@ -1,9 +1,7 @@
 package com.team6.cafe.domain.orderCoffee.dto;
 
 import jakarta.validation.constraints.NotNull;
-
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter

--- a/backend/src/main/java/com/team6/cafe/domain/orderCoffee/dto/OrderCoffeeRequestDto.java
+++ b/backend/src/main/java/com/team6/cafe/domain/orderCoffee/dto/OrderCoffeeRequestDto.java
@@ -17,4 +17,9 @@ public class OrderCoffeeRequestDto {
 
 	@Min(1)
 	private int quantity; // 최소수량 1개
+
+	public OrderCoffeeRequestDto(Long coffeeId, int quantity) {
+		this.coffeeId = coffeeId;
+		this.quantity = quantity;
+	}
 }

--- a/backend/src/main/java/com/team6/cafe/domain/orderCoffee/dto/OrderCoffeeResponseDto.java
+++ b/backend/src/main/java/com/team6/cafe/domain/orderCoffee/dto/OrderCoffeeResponseDto.java
@@ -13,4 +13,12 @@ public class OrderCoffeeResponseDto {
 	private Long id;
 	private CoffeeResponseDto coffee; // 커피 정보 포함
 	private int quantity;
+
+	public static OrderCoffeeResponseDto from(OrderCoffee orderCoffee) {
+		return new OrderCoffeeResponseDto(
+			orderCoffee.getId(),
+			CoffeeResponseDto.from(orderCoffee.getCoffee()),
+			orderCoffee.getQuantity()
+		);
+	}
 }

--- a/backend/src/main/java/com/team6/cafe/domain/orderCoffee/entity/OrderCoffee.java
+++ b/backend/src/main/java/com/team6/cafe/domain/orderCoffee/entity/OrderCoffee.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,5 +36,12 @@ public class OrderCoffee {
 	private Coffee coffee;
 
 	private int quantity; // 커피 수량
+
+	@Builder
+	public OrderCoffee(Order order, Coffee coffee, int quantity) {
+		this.order = order;
+		this.coffee = coffee;
+		this.quantity = quantity;
+	}
 }
 

--- a/backend/src/main/java/com/team6/cafe/global/BaseInitData.java
+++ b/backend/src/main/java/com/team6/cafe/global/BaseInitData.java
@@ -1,0 +1,42 @@
+package com.team6.cafe.global;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import com.team6.cafe.domain.coffee.dto.CoffeeRequestDto;
+import com.team6.cafe.domain.coffee.service.CoffeeService;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class BaseInitData {
+	private final CoffeeService coffeeService;
+
+	@Autowired
+	@Lazy
+	private BaseInitData self;
+
+	@Bean
+	public ApplicationRunner applicationRunner() {
+		return args -> {
+			self.coffeeInit();
+		};
+	}
+
+	@Transactional
+	public void coffeeInit() {
+		if(coffeeService.count() > 0){
+			return;
+		}
+
+		coffeeService.create(new CoffeeRequestDto("Columbia Nariño", 5000, "https://cdn.pixabay.com/photo/2017/09/04/18/39/coffee-2714970_960_720.jpg"));
+		coffeeService.create(new CoffeeRequestDto("Brazil Serra do Caparaó", 6000, "https://cdn.pixabay.com/photo/2016/01/02/04/59/coffee-1117933_1280.jpg"));
+		coffeeService.create(new CoffeeRequestDto("Columbia Quindio(White Wine Extended Fermentation)", 7000, "https://cdn.pixabay.com/photo/2022/11/01/05/18/coffee-7561288_1280.jpg"));
+		coffeeService.create(new CoffeeRequestDto("Ethiopia Sidamo", 8000, "https://cdn.pixabay.com/photo/2015/05/31/10/54/coffee-791045_1280.jpg"));
+	}
+}

--- a/backend/src/test/java/com/team6/cafe/CafeApplicationTests.java
+++ b/backend/src/test/java/com/team6/cafe/CafeApplicationTests.java
@@ -1,13 +1,68 @@
 package com.team6.cafe;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.List;
+
+import com.team6.cafe.domain.order.dto.OrderRequestDto;
+import com.team6.cafe.domain.order.dto.OrderResponseDto;
+import com.team6.cafe.domain.order.service.OrderService;
+import com.team6.cafe.domain.orderCoffee.dto.OrderCoffeeRequestDto;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class CafeApplicationTests {
+	@Autowired
+	private OrderService orderService;
+
+	@Autowired
+	private MockMvc mvc;
 
 	@Test
 	void contextLoads() {
 	}
 
+	@Test
+	@DisplayName("주문 생성 테스트")
+	void createTest() throws Exception {
+		OrderRequestDto requestDto = new OrderRequestDto("example@team6.com", "Seoul", 20000, List.of(
+			new OrderCoffeeRequestDto(1L, 2),
+			new OrderCoffeeRequestDto(2L, 1)
+		));
+
+		OrderResponseDto responseDto = new OrderResponseDto();
+		responseDto.setId(1L);
+		responseDto.setEmail("example@team6.com");
+		responseDto.setAddress("Seoul");
+		responseDto.setTotalPrice(20000);
+
+		mvc.perform(post("/api/order/create")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+                        {
+                            "email": "example@team6.com",
+                            "address": "Seoul",
+                            "totalPrice": 20000,
+                            "orderCoffees": [ {"coffeeId": 1, "quantity": 2}, { "coffeeId": 2, "quantity": 1 } ]
+                        }
+                    """))
+			.andExpect(status().isOk())  // HTTP 상태 코드 201 확인
+			.andExpect(jsonPath("$.email").value("example@team6.com"))  // 이메일 값 검증
+			.andExpect(jsonPath("$.totalPrice").value(20000))  // 총 가격 검증
+			.andExpect(jsonPath("$.orderCoffees[0].coffee.id").value(1))  // 커피 ID 검증
+			.andExpect(jsonPath("$.orderCoffees[0].coffee.name").value("Columbia Nariño"))  // 커피 이름 검증
+			.andDo(print());
+	}
 }


### PR DESCRIPTION
## 📌 과제 설명
주문 생성 기능 구현 및 테스트 코드 추가

## 👩‍💻 요구 사항과 구현 내용
일부 엔티티에 빌더 패턴 작성하고, OrderService create를 통해 주문을 생성하는 기능을 추가하였습니다. (API 페이지에서 RequestBody 참고)
BaseInitData 추가하여 실행 시 4개의 커피를 추가하도록 작성했습니다.

## ✅ 피드백 반영사항 
테스트 코드를 추가하였습니다

## ✅ PR 포인트 & 궁금한 점
추가적으로 order 테이블명이 예약어라 오류가 발생해서, 테이블명을 orders로 변경했습니다
(Order 엔티티의 **@Table(name = "orders")**)
Postman을 통해 정상 작동 확인했습니다!